### PR TITLE
Windows環境でnpm testした時にmochaが*.tsを見つけられない問題を修正しました

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "clean": "del coverage",
     "fmt": "tsfmt -r",
     "pretest": "npm run lint",
-    "test": "mocha --compilers ts:espower-typescript/guess 'test/**/*.ts'",
-    "watch": "mocha --compilers ts:espower-typescript/guess --watch 'test/**/*.ts'",
+    "test": "mocha --compilers ts:espower-typescript/guess \"test/**/*.ts\"",
+    "watch": "mocha --compilers ts:espower-typescript/guess --watch \"test/**/*.ts\"",
     "test-coverage": "mocha --compilers ts:ts-node/register --require source-map-support/register",
     "coverage": "npm run clean && nyc --reporter html --reporter text --extension .ts npm run test-coverage"
   }


### PR DESCRIPTION
Windows環境で`npm test`した場合、引数をダブルクオートしないと`*.ts`ファイルを`mocha`コマンドが見つけられない問題を修正しました

## 修正前
```
azusa@DESKTOP-5QM2O5K C:\Users\azusa\git\typescript-mocha [master +1 ~1 -0]

> npm test

> typescript-mocha@0.1.0 pretest C:\Users\azusa\git\typescript-mocha

> npm run lint



> typescript-mocha@0.1.0 lint C:\Users\azusa\git\typescript-mocha

> tslint -c tslint.json 'src/**/*.ts' 'test/**/*.ts'



> typescript-mocha@0.1.0 test C:\Users\azusa\git\typescript-mocha

> mocha --compilers ts:espower-typescript/guess 'test/*.ts'

Warning: Could not find any test files matching pattern: 'test/*.ts'

No test files found

npm ERR! Test failed.  See above for more details.
```

## 修正後(Windows host)
```
azusa@DESKTOP-5QM2O5K C:\Users\azusa\git\typescript-mocha [mocha-on-windows-hosts]            
> npm test                                                                                    
                                                                                              
> typescript-mocha@0.1.0 pretest C:\Users\azusa\git\typescript-mocha                          
> npm run lint                                                                                
                                                                                              
                                                                                              
> typescript-mocha@0.1.0 lint C:\Users\azusa\git\typescript-mocha                             
> tslint -c tslint.json 'src/**/*.ts' 'test/**/*.ts'                                          
                                                                                              
                                                                                              
> typescript-mocha@0.1.0 test C:\Users\azusa\git\typescript-mocha                             
> mocha --compilers ts:espower-typescript/guess "test/**/*.ts"                                
                                                                                              
                                                                                              
                                                                                              
  Sample                                                                                      
    .statusは、                                                                                 
      √ trueであるべき                                                                             
    #say()は、                                                                                  
      √ "Hello TDDBC!"が返ってくるべき                                                                
                                                                                              
                                                                                              
  2 passing (13ms)                                                                            
                                                                                                                                                                                           
```

## 修正後(Linux host)
```
[git][* mocha-on-windows-hosts]:$ npm test                                     [~/typescript-mocha]

> typescript-mocha@0.1.0 pretest /home/vagrant/typescript-mocha
> npm run lint


> typescript-mocha@0.1.0 lint /home/vagrant/typescript-mocha
> tslint -c tslint.json 'src/**/*.ts' 'test/**/*.ts'


> typescript-mocha@0.1.0 test /home/vagrant/typescript-mocha
> mocha --compilers ts:espower-typescript/guess "test/**/*.ts"



  Sample
    .statusは、
      ✓ trueであるべき
    #say()は、
      ✓ "Hello TDDBC!"が返ってくるべき


  2 passing (8ms)

```